### PR TITLE
Reimplement disk_info() function

### DIFF
--- a/grml-hwinfo
+++ b/grml-hwinfo
@@ -155,20 +155,9 @@ exectest() {
   fi
 }
 
-# based on https://github.com/faiproject/fai/blob/master/lib/fai-disk-info
-checkdisk() {
-  local isdisk device
-  while read _ _ _ device _ ; do
-    isdisk=1
-    # skip CDROMs
-    [ "$(stat -c %G /dev/"${device}")" = "disk" ] || isdisk=0
-    [ "$isdisk" -eq 1 ] && echo "$device"
-  done
-}
-
 disk_info() {
-  # the variable holds a newline separated list of devices
-  disklist=$(egrep ' etherd/e[[:digit:]]+\.[[:digit:]]+\b| i2o/hd.+\b| cciss/c.+d.+\b| ida/c.+d.+\b| rd/c.+d.+\b| fio.\b| hd.\b| sd[a-z]{1,2}\b|/disc\b| vd.\b| xvd.\b' /proc/partitions | checkdisk)
+  # the variable holds a newline separated list of disk block devices, excluding loopback and CD-ROM devices
+  disklist=$(lsblk -nd -o NAME -e 7,11)
 }
 
 


### PR DESCRIPTION
The disklist variable holds a newline separated list of devices that is used to get various infos about the given disks, such as sfdisk, smartctl, hdparm, fdisk, parted, sdparm, sg_inq and the output of file.

Unfortunately NVMe disks were not included in the list.

lsblk lists information about all available or specified block devices excluding the loopback and CD-ROM devices. The checkdisk() function is is no longer needed.

FTR, the major:minor device numbers are listed in the Kernel documentation, in case we need to exclude more disk device types:

https://www.kernel.org/doc/Documentation/admin-guide/devices.txt

Closes: grml/grml-hwinfo#6