### PR TITLE
grml-hwinfo: Add inxi output + warn user if run without an X server

### DIFF
--- a/grml-hwinfo
+++ b/grml-hwinfo
@@ -191,6 +191,10 @@ cd "${OUTDIR}" || exit 1
   fi
   uname -a > ./uname
 
+  # inxi
+  exectest inxi  && inxi -F -xx > ./inxi 2>./inxi.error
+  exectest inxi  && inxi -FJ --admin > ./inxi_admin 2>./inxi_admin.error
+
   # disks / devices
   [ -f /proc/scsi/scsi ] && cat /proc/scsi/scsi > scsi
   exectest lspci && lspci -nn > ./lspci

--- a/grml-hwinfo
+++ b/grml-hwinfo
@@ -172,6 +172,22 @@ get_network_devices() {
   done
 }
 
+# Check if X server is running
+#
+# If xset is missing, we rely on the existence of the $DISPLAY variable.
+NO_DISPLAY=0
+if exectest xset ; then
+  if ! timeout 1s xset q &>/dev/null ; then
+    NO_DISPLAY=1
+  fi
+elif [ -z "${DISPLAY}" ] ; then
+    NO_DISPLAY=1
+fi
+
+if [ "${NO_DISPLAY}" -eq 1 ] ; then
+  $_opt_quiet || echo "W: Running without X server. Not all data will be collected."
+fi
+
 cd "${OUTDIR}" || exit 1
 (
   if ! $_opt_quiet ; then
@@ -324,7 +340,7 @@ cd "${OUTDIR}" || exit 1
   dpkg -S "/boot/vmlinuz-$(uname -r)" >> running_kernel 2>>running_kernel.error
 
   # X stuff
-  if [ -n "${DISPLAY}" ] ; then
+  if [ "${NO_DISPLAY}" -eq 0 ] ; then
     exectest xviddetect  && xviddetect         > ./xviddetect
     exectest xvidtune    && xvidtune -show     > ./xdivtune
     exectest xrandr      && xrandr             > ./xrandr


### PR DESCRIPTION
Add inxi output:

* `inxi -F -xx` shows full with extra data level 2 output for inxi
  (except some verbose options)
* `inxi -FJ --admin` shows full with admin extra data (which sets extra
  data level 3) and `-J` which shows USB data for attached Hubs and
  Devices.

Extra Data Level 2 is enough for most use cases, but admin extra data
should show everything possible.

While at it, we also warn the user if grml-hwinfo is run without an X server, as not all data is collected.