### PR TITLE
Log stderr of sdparm to file sdparm.error

### DIFF
--- a/grml-hwinfo
+++ b/grml-hwinfo
@@ -459,8 +459,10 @@ cd "${OUTDIR}" || exit 1
 
       if exectest sdparm ; then
         echo -e "sdparm --all --long /dev/${disk}:\n" >> sdparm
-        sdparm --all --long "/dev/$disk" >> ./sdparm
+        echo -e "stderr for sdparm --all --long /dev/${disk}:\n" >> sdparm.error
+        sdparm --all --long "/dev/$disk" >> ./sdparm 2>> ./sdparm.error
         echo -e "\n\n" >> sdparm
+        echo -e "\n\n" >> sdparm.error
       fi
 
       if exectest sg_inq ; then


### PR DESCRIPTION
There might be output on stderr like:

```
| root@grml ~ # sdparm --all --long  /dev/sda > /dev/null
| descriptor overflows reply len (12) for AT_LAST.1
| descriptor overflows reply len (12) for CDA_UNIT.1
| descriptor overflows reply len (12) for CDB_UNIT.1
| descriptor overflows reply len (12) for IOA_MODE.1
```

Ensure to log it to file "sdparm.error".

Closes: grml/grml-hwinfo#10