### PR TITLE
grml-hwinfo: Update inxi output

### DIFF
--- a/grml-hwinfo
+++ b/grml-hwinfo
@@ -256,8 +256,12 @@ cd "${OUTDIR}" || exit 1
   uname -a > ./uname
 
   # inxi
-  exectest inxi  && inxi -F -xx > ./inxi 2>./inxi.error
-  exectest inxi  && inxi -FJ --admin > ./inxi_admin 2>./inxi_admin.error
+  exectest inxi  && inxi -FJm > ./inxi_standard 2>./inxi_standard.error
+  exectest inxi  && inxi -FJmz > ./inxi_standard_filter 2>./inxi_standard_filter.error
+  exectest inxi  && inxi -FJm -xx > ./inxi_extra 2>./inxi_extra.error
+  exectest inxi  && inxi -FJmz -xx > ./inxi_extra_filter 2>./inxi_extra_filter.error
+  exectest inxi  && inxi -FJm --admin > ./inxi_admin 2>./inxi_admin.error
+  exectest inxi  && inxi -FJmz --admin > ./inxi_admin_filter 2>./inxi_admin_filter.error
 
   # disks / devices
   [ -f /proc/scsi/scsi ] && cat /proc/scsi/scsi > scsi


### PR DESCRIPTION
For some reason the full output for inxi does not show extra verbose options such as -d -f -i -J -l -m -o -p -r -t -u -x.

As grml-hwinfo collects a lot of information regarding hardware, we should include as much useful information as possible.

Skipped the following flags:

* `-d` [skipped]: Show optical drive data as well as -D hard drive data.
* `-l` [skipped]: Show partition labels.
* `-o` [skipped]: Show unmounted partition information (includes UUID and LABEL if available).
* `-p` [skipped]: Show full Partition information
* `-r` [skipped]: Show distro repository data.
* `-t` [skipped]: Show processes.
* `-u` [skipped]: Show partition UUIDs.

Included the following flags:

* `-f`: Show all CPU flags used, not just the short list.
* `-i`: Show WAN IP address and local interfaces
* `-J`: Show USB data for attached Hubs and Devices.
* `-m`: Memory (RAM) data.

Updated the output files to include the standard output, extra data level 2 and admin extra data and created "_filter" files for each output with filtered data (which adds security filters for IP addresses, serial numbers, MAC, location (-w), and user home directory name and removes the hostname).

The _filter files can be used when posting online. It is better to have confidential data filterer out from the output than to do so afterwards.

Updates: grml/grml-hwinfo#8