### PR TITLE
Improve lsblk output

### DIFF
--- a/grml-hwinfo
+++ b/grml-hwinfo
@@ -481,7 +481,7 @@ cd "${OUTDIR}" || exit 1
     exectest dmsetup && dmsetup ls > dmsetup_ls 2>dmsetup_ls.error
     exectest dmsetup && dmsetup ls --tree > dmsetup_ls_tree 2>dmsetup_ls_tree.error
     if exectest lsblk ; then
-      lsblk > ./lsblk 2>./lsblk.error
+      lsblk -o +LABEL,PARTLABEL,UUID,FSTYPE,SERIAL > ./lsblk 2>./lsblk.error
       # json output is supported since util-linux v2.33.1:
       if lsblk --help | grep -q 'json' ; then
         lsblk --json > ./json/lsblk 2>./json/lsblk.error


### PR DESCRIPTION
Please compare the following outputs:

  ❯ lsblk /dev/sda
  NAME   MAJ:MIN RM  SIZE RO TYPE MOUNTPOINTS
  sda      8:0    0  1,8T  0 disk
  └─sda1   8:1    0  1,8T  0 part /media/jkirk/Transcend

  ❯ lsblk -f /dev/sda
  NAME   FSTYPE FSVER LABEL     UUID                                 FSAVAIL FSUSE% MOUNTPOINTS
  sda
  └─sda1 ntfs         Transcend 96EC52DAEC52SNIP                      102,7G    94% /media/jkirk/Transcend

  ❯ lsblk -o +LABEL,PARTLABEL,UUID,FSTYPE,SERIAL /dev/sda
  NAME   MAJ:MIN RM  SIZE RO TYPE MOUNTPOINTS            LABEL     PARTLABEL UUID                                 FSTYPE SERIAL
  sda      8:0    0  1,8T  0 disk                                                                                        S36VJ9EGB0SNIP
  └─sda1   8:1    0  1,8T  0 part /media/jkirk/Transcend Transcend           96EC52DAEC52SNIP                     ntfs

Option `-f, --fs` outputs info about filesystems.
This option is equivalent to -o NAME,FSTYPE,FSVER,LABEL,UUID,FSAVAIL,FSUSE%,MOUNTPOINTS.

FSAVAIL and FSUE% could be added to my custom output list, but on a Grml system the devices are usually not mounted and even if they are, we already capture the df output.

IMHO, PARTLABEL and SERIAL are more interesting in this regard.