### PR TITLE
d/control: remove old Suggests: iproute alternative

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -30,7 +30,7 @@ Suggests:
  hdparm,
  hwinfo,
  i2c-tools,
- iproute2 | iproute,
+ iproute2,
  laptop-detect,
  lsscsi,
  lvm2,


### PR DESCRIPTION
jessie already had iproute2.

Found in https://qa.debian.org/debcheck.php?dist=unstable&package=grml-hwinfo